### PR TITLE
Plists for NGINX and MYSQL

### DIFF
--- a/modules/mariadb/org.mysql.mysql.plist
+++ b/modules/mariadb/org.mysql.mysql.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key><string>mysql</string>
+        <key>Program</key><string>/usr/local/mysql/bin/mysqld_safe</string>
+        <key>KeepAlive</key><true/>
+    </dict>
+</plist>

--- a/modules/nginx/org.nginx.nginx.plist
+++ b/modules/nginx/org.nginx.nginx.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+"http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>Label</key><string>nginx</string>
+        <key>Program</key><string>/usr/local/nginx/sbin/nginx</string>
+        <key>KeepAlive</key><true/>
+    </dict>
+</plist>


### PR DESCRIPTION
Wrote plists for NGINX and MYSQL. These will need to be relocated during module install to:

```
~/Library/LaunchAgents for MySQL
```

and

```
/Library/LaunchAgents for Nginx as it needs to be started as root
```

Then each service needs a first start to enable autostart with:

```
launchctl load -w ~/Library/LaunchAgents/org.mysql.mysqld.plist
```

and

```
sudo launchctl load -w /Library/LaunchDaemons/org.nginx.nginx.plist
```
